### PR TITLE
Bump version to 2022.2.1

### DIFF
--- a/custom_components/rpi_gpio/manifest.json
+++ b/custom_components/rpi_gpio/manifest.json
@@ -6,5 +6,5 @@
   "requirements": ["RPi.GPIO==0.7.1a4"],
   "codeowners": ["@thecode"],
   "iot_class": "local_push",
-  "version": "0.1.0"
+  "version": "2022.2.1"
 }


### PR DESCRIPTION
Previous version was not using calendar versioning and did not match the release tag
