### PR TITLE
Bump RPi.GPIO to 0.7.1

### DIFF
--- a/custom_components/rpi_gpio/manifest.json
+++ b/custom_components/rpi_gpio/manifest.json
@@ -3,7 +3,7 @@
   "name": "Raspberry Pi GPIO",
   "documentation": "https://github.com/thecode/ha-rpi_gpio",
   "issue_tracker": "https://github.com/thecode/ha-rpi_gpio/issues",
-  "requirements": ["RPi.GPIO==0.7.1a4"],
+  "requirements": ["RPi.GPIO==0.7.1"],
   "codeowners": ["@thecode"],
   "iot_class": "local_push",
   "version": "2022.6.0"


### PR DESCRIPTION
0.7.1 Release notes:
- Better RPi board + peri_addr detection (issue 190 / 191)
- Fix PyEval_InitThreads deprecation warning for Python 3.9 (issue 188)
- Fix build using GCC 10 (issue 187)
- Fix docstrings to not include licence
- Remove Debian/Raspbian stretch packaging support
- Use setuptools instead of distutils
- Added detection of Zero 2 W
- Tested and working with Python 2.7, 3.7, 3.8, 3.9, 3.10

**There are no code changes from `0.7.1a4` this just bumps from a pre-released version to the latest release.**
