### PR TITLE
Minor error handing and tracing improvements

### DIFF
--- a/custom_components/rpi_gpio/binary_sensor.py
+++ b/custom_components/rpi_gpio/binary_sensor.py
@@ -85,5 +85,5 @@ class GPIODBinarySensor(BinarySensorEntity):
         self.async_write_ha_state()
 
     def handle_event(self):
-        self._attr_is_on = self._hub.update(self._port)
+        self._attr_is_on = self._hub.get_line_value(self._port)
         self.schedule_update_ha_state(False)

--- a/custom_components/rpi_gpio/cover.py
+++ b/custom_components/rpi_gpio/cover.py
@@ -114,7 +114,7 @@ class GPIODCover(CoverEntity):
         self.async_write_ha_state()
 
     def handle_event(self):
-        self._attr_is_closed = self._hub.update(self._state_port)
+        self._attr_is_closed = self._hub.get_line_value(self._state_port)
         self.schedule_update_ha_state(False)
 
     def close_cover(self, **kwargs):

--- a/custom_components/rpi_gpio/hub.py
+++ b/custom_components/rpi_gpio/hub.py
@@ -188,5 +188,4 @@ class Hub:
         _LOGGER.debug(f"in add_cover {relay_port} {state_port}")
         self.add_switch(entity, relay_port, relay_active_low, relay_bias, relay_drive, init_output_value = False)
         self.add_sensor(entity, state_port, state_active_low, state_bias, 50)
-        self.update_lines()
 

--- a/custom_components/rpi_gpio/switch.py
+++ b/custom_components/rpi_gpio/switch.py
@@ -76,7 +76,7 @@ class GPIODSwitch(SwitchEntity, RestoreEntity):
     _attr_should_poll = False
 
     def __init__(self, hub, name, port, unique_id, active_low, bias, drive, persistent):
-        _LOGGER.debug(f"GPIODSwitch init: {port} - {name} - {unique_id} - active_low: {active_low} - bias: {bias} - drive: {drive}")
+        _LOGGER.debug(f"GPIODSwitch init: {port} - {name} - {unique_id} - active_low: {active_low} - bias: {bias} - drive: {drive} - persistent: {persistent}")
         self._hub = hub
         self._attr_name = name
         self._attr_unique_id = unique_id

--- a/custom_components/rpi_gpio/switch.py
+++ b/custom_components/rpi_gpio/switch.py
@@ -109,5 +109,5 @@ class GPIODSwitch(SwitchEntity, RestoreEntity):
         self.async_write_ha_state()
 
     def handle_event(self):
-        self._attr_is_on = self._hub.update(self._port)
+        self._attr_is_on = self._hub.get_line_value(self._port)
         self.schedule_update_ha_state(False)

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
   "name": "Raspberry Pi GPIO",
-  "homeassistant": "2022.7.0"
+  "homeassistant": "2024.9.0"
 }


### PR DESCRIPTION
1. Rename update to get_line_value
2. Add specific exceptions when hub is not online and user is using the switches
3. Remove the duplicate update_lines call in the cover case