### PR TITLE
Fix regressions in cover

### DIFF
--- a/custom_components/rpi_gpio/hub.py
+++ b/custom_components/rpi_gpio/hub.py
@@ -199,7 +199,8 @@ class Hub:
                 bias = BIAS[bias],
                 active_low = active_low)},
         ) as request:
-            entity._attr_is_on = True if request.get_value(port) == Value.ACTIVE else False
+            # Although we prefer to set the _attr_is_on attribute, in cover it does not exists for whatever reason.
+            entity.is_on = True if request.get_value(port) == Value.ACTIVE else False
 
         _LOGGER.debug(f"current value for port {port}: {entity.is_on}")
         self._edge_events = True


### PR DESCRIPTION
Although we prefer to set the _attr_is_on attribute, in cover it does not exists for whatever reason.