### PR TITLE
Skip failed entities instead of stop loading all of them

### DIFF
--- a/custom_components/rpi_gpio/binary_sensor.py
+++ b/custom_components/rpi_gpio/binary_sensor.py
@@ -52,17 +52,20 @@ async def async_setup_platform(
 
     sensors = []
     for sensor in config.get(CONF_SENSORS):
-        sensors.append(
-            GPIODBinarySensor(
-                hub,
-                sensor[CONF_NAME],
-                sensor[CONF_PORT],
-                sensor.get(CONF_UNIQUE_ID) or f"{DOMAIN}_{sensor[CONF_PORT]}_{sensor[CONF_NAME].lower().replace(' ', '_')}",
-                sensor.get(CONF_INVERT_LOGIC),
-                sensor.get(CONF_PULL_MODE),
-                sensor.get(CONF_BOUNCETIME)
+        try:
+            sensors.append(
+                GPIODBinarySensor(
+                    hub,
+                    sensor[CONF_NAME],
+                    sensor[CONF_PORT],
+                    sensor.get(CONF_UNIQUE_ID) or f"{DOMAIN}_{sensor[CONF_PORT]}_{sensor[CONF_NAME].lower().replace(' ', '_')}",
+                    sensor.get(CONF_INVERT_LOGIC),
+                    sensor.get(CONF_PULL_MODE),
+                    sensor.get(CONF_BOUNCETIME)
+                )
             )
-        )
+        except Exception as e:
+            _LOGGER.error(f"Failed to add binary sensor {sensor[CONF_NAME]} for port {sensor[CONF_PORT]}: {e}")
 
     async_add_entities(sensors)
 

--- a/custom_components/rpi_gpio/cover.py
+++ b/custom_components/rpi_gpio/cover.py
@@ -71,21 +71,24 @@ async def async_setup_platform(
     invert_relay = config[CONF_INVERT_RELAY]
     covers = []
     for cover in config.get(CONF_COVERS):
-        covers.append(
-            GPIODCover(
-                hub,
-                cover[CONF_NAME],
-                cover.get(CONF_RELAY_PIN),
-                relay_time,
-                invert_relay,
-                "AS_IS",
-                "PUSH_PULL",
-                cover.get(CONF_STATE_PIN),
-                state_pull_mode,
-                invert_state,
-                cover.get(CONF_UNIQUE_ID) or f"{DOMAIN}_{cover.get(CONF_RELAY_PIN)}_{cover[CONF_NAME].lower().replace(' ', '_')}",
+        try:
+            covers.append(
+                GPIODCover(
+                    hub,
+                    cover[CONF_NAME],
+                    cover.get(CONF_RELAY_PIN),
+                    relay_time,
+                    invert_relay,
+                    "AS_IS",
+                    "PUSH_PULL",
+                    cover.get(CONF_STATE_PIN),
+                    state_pull_mode,
+                    invert_state,
+                    cover.get(CONF_UNIQUE_ID) or f"{DOMAIN}_{cover.get(CONF_RELAY_PIN)}_{cover[CONF_NAME].lower().replace(' ', '_')}",
+                )
             )
-        )
+        except Exception as e:
+            _LOGGER.error(f"Failed to add cover {cover[CONF_NAME]} for port {cover.get(CONF_RELAY_PIN)}:{cover.get(CONF_STATE_PIN)}: {e}")
 
     async_add_entities(covers)
 

--- a/custom_components/rpi_gpio/switch.py
+++ b/custom_components/rpi_gpio/switch.py
@@ -56,18 +56,21 @@ async def async_setup_platform(
 
     switches = []
     for switch in config.get(CONF_SWITCHES):
-        switches.append(
-            GPIODSwitch(
-                hub,
-                switch[CONF_NAME],
-                switch[CONF_PORT],
-                switch.get(CONF_UNIQUE_ID) or f"{DOMAIN}_{switch[CONF_PORT]}_{switch[CONF_NAME].lower().replace(' ', '_')}",
-                switch.get(CONF_INVERT_LOGIC),
-                switch.get(CONF_PULL_MODE),
-                switch.get(CONF_DRIVE),
-                switch[CONF_PERSISTENT]
+        try:
+            switches.append(
+                GPIODSwitch(
+                    hub,
+                    switch[CONF_NAME],
+                    switch[CONF_PORT],
+                    switch.get(CONF_UNIQUE_ID) or f"{DOMAIN}_{switch[CONF_PORT]}_{switch[CONF_NAME].lower().replace(' ', '_')}",
+                    switch.get(CONF_INVERT_LOGIC),
+                    switch.get(CONF_PULL_MODE),
+                    switch.get(CONF_DRIVE),
+                    switch[CONF_PERSISTENT]
+                )
             )
-        )
+        except Exception as e:
+            _LOGGER.error(f"Failed to add switch {switch[CONF_NAME]} for port {switch[CONF_PORT]}: {e}")
 
     async_add_entities(switches)
 


### PR DESCRIPTION
change ```async_setup_platform``` to just skip entities with HW issues instead of throwing and skipping the rest of the entities.
