### PR TITLE
Add Resources section with interactive GPIO pinout reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,5 +209,9 @@ switch:
         name: "Speaker Relay"
 ```
 
+# Resources
+
+- [Raspberry Pi GPIO Pinout](https://raspberry.tips/en/raspberry-pi-gpio-pinout) — interactive reference for all 40 GPIO pins including BCM numbers, functions, and voltage specs
+
 # Reporting issues
 *Before* reporting issues please enable debug logging as described [here](https://www.home-assistant.io/docs/configuration/troubleshooting/#enabling-debug-logging), check logs and report issue attaching the log file and the relevant YAML section.


### PR DESCRIPTION
﻿Adds a Resources section before "Reporting issues" with a link to an interactive GPIO pinout reference. The README already explains that port numbers are BCM GPIO numbers and not physical pin numbers — this gives readers a direct reference to look up the mapping without leaving the documentation flow.
